### PR TITLE
fix: 使用os库替换遗弃的io/ioutil

### DIFF
--- a/common/parse.go
+++ b/common/parse.go
@@ -2,14 +2,14 @@ package common
 
 import (
 	"flag"
-	"github.com/wgpsec/ENScan/common/utils"
-	"github.com/wgpsec/ENScan/common/utils/gologger"
-	yaml "gopkg.in/yaml.v2"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/wgpsec/ENScan/common/utils"
+	"github.com/wgpsec/ENScan/common/utils/gologger"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func Parse(options *ENOptions) {
@@ -34,7 +34,7 @@ func Parse(options *ENOptions) {
 
 	//加载配置信息~
 	conf := new(ENConfig)
-	yamlFile, err := ioutil.ReadFile(cfgYName)
+	yamlFile, err := os.ReadFile(cfgYName)
 	if err != nil {
 		gologger.Fatalf("配置文件解析错误 #%v ", err)
 	}


### PR DESCRIPTION
io/ioutil库已经被遗弃，不推荐使用，具体见:https://pkg.go.dev/io/ioutil