### PR TITLE
增加分支机构和子公司名称过滤功能

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -49,6 +49,7 @@ type ENOptions struct {
 	OutPutType     string // 导出文件类型
 	IsApiMode      bool
 	ENConfig       *ENConfig
+	BranchFilter string
 }
 
 // EnsGo EnScan 接口请求通用格式接口

--- a/common/flag.go
+++ b/common/flag.go
@@ -41,6 +41,7 @@ func Flag(Info *ENOptions) {
 	flag.BoolVar(&Info.IsSearchBranch, "is-branch", false, "深度查询分支机构信息（数量巨大）")
 	flag.BoolVar(&Info.IsJsonOutput, "json", false, "json导出")
 	flag.StringVar(&Info.Output, "out-dir", "", "结果输出的文件夹位置(默认为outs)")
+	flag.StringVar(&Info.BranchFilter, "branch-filter", "", "提供一个正则表达式，名称匹配该正则的分支机构和子公司会被跳过")
 	flag.StringVar(&Info.UPOutFile, "out-update", "", "导出指定范围文件，自更新")
 	flag.StringVar(&Info.OutPutType, "out-type", "xlsx", "导出的文件后缀 默认xlsx")
 	flag.BoolVar(&Info.IsDebug, "debug", false, "是否显示debug详细信息")


### PR DESCRIPTION
某些公司，下属子公司或者分支机构有各种各样的营业厅、营业部、送水站、服务站、服务中心，这些营业厅都是没有任何互联网资产的，但是却占了分支机构总量的80%~90%以上，导致查询速率降低数十倍，频繁触发安全验证。

提供一个参数`-branch-filter`，用正则表达式过滤子公司/分支机构名称，名称匹配该正则表达式的分支机构和子公司会被跳过。