### PR TITLE
修复批量查询功能中的WaitGroup死锁问题

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/wgpsec/ENScan
 
-go 1.24.0
-
-toolchain go1.24.5
+go 1.23.0
 
 require (
 	github.com/antchfx/htmlquery v1.2.4


### PR DESCRIPTION
- 修复SearchByKeyWord函数中的空结果检查和错误处理
- 修复processTask函数中的WaitGroup死锁问题，确保即使查询失败也能继续处理下一个任务
- 在错误处理路径中正确调用enWg.Done()，避免程序卡住
- 降低go.mod中的Go版本要求从1.24.0到1.23.0以兼容更多环境

修复后的程序能够稳定处理包含无效公司名称的批量查询任务。
macarm64